### PR TITLE
feat: create gh draft release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,22 +3,15 @@ name: release
 on: workflow_dispatch
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-20.04
+  release:
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: denoland/setup-deno@v1.1.0
         with:
           deno-version: v1.x.x
-      - run: |
-          TAG=$(deno run --allow-run=git --unstable mod.ts)
-          echo $TAG
-          gh release create $TAG --generate-notes
+      - run: deno run --allow-run='gh,git' --unstable mod.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pipeline.
 
 ## Usage
 
-`deno run --allow-run=git --unstable https://deno.land/x/denotation@v0.1.1/mod.ts`
+`deno run --allow-run=git --unstable https://deno.land/x/denotation@v0.2.0/mod.ts`
 
 This will run the script and look at the commits made since the last git tag,
 for example `v1.0.0`. Depending on the conventional commit messages it will
@@ -40,7 +40,7 @@ jobs:
       - uses: denoland/setup-deno@v1.1.0
         with:
           deno-version: v1.x.x
-      - run: deno run --allow-run='gh,git' --unstable https://deno.land/x/denotation@v0.1.1/mod.ts
+      - run: deno run --allow-run='gh,git' --unstable https://deno.land/x/denotation@v0.2.0/mod.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -26,11 +26,23 @@ The following example shows how to use `denotation` as a step in GitHub Actions
 together with the GitHub CLI to make a release:
 
 ```yaml
-- run: |
-    TAG=$(deno run --allow-run=git --unstable https://deno.land/x/denotation@v0.1.1/mod.ts)
-    gh release create $TAG --generate-notes
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+name: release
+
+on: workflow_dispatch
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: denoland/setup-deno@v1.1.0
+        with:
+          deno-version: v1.x.x
+      - run: deno run --allow-run='gh,git' --unstable https://deno.land/x/denotation@v0.1.1/mod.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Contributing

--- a/mod.ts
+++ b/mod.ts
@@ -103,6 +103,13 @@ if (!nextVersion) {
   );
 }
 
-await writeAll(Deno.stdout, new TextEncoder().encode(nextVersion));
+// gh release create --draft --generate-notes $TAG
+await spawnProcess("gh", [
+  "release",
+  "create",
+  "--draft",
+  "--generate-notes",
+  nextVersion,
+]);
 
-// v2.5.0-alpha.0
+await writeAll(Deno.stdout, new TextEncoder().encode(nextVersion));


### PR DESCRIPTION
`gh release create` is now run from the script creating a draft release with generated release notes. This is most suitable for Continuous Delivery scenarios

`--generate-notes` includes all types of commits, including thing like `feat(ci)` and `feat(testing)` that should not usually cause a minor version increment. A future option should be made where the release notes are automatically filtered and then the release could also be published right away, without first making a draft.